### PR TITLE
CUSTCOM-247 Cleanups

### DIFF
--- a/appserver/tests/payara-samples/samples/jaxws-security/src/test/java/fish/payara/samples/jaxws/security/InsecureSSLConfigurator.java
+++ b/appserver/tests/payara-samples/samples/jaxws-security/src/test/java/fish/payara/samples/jaxws/security/InsecureSSLConfigurator.java
@@ -2,7 +2,15 @@ package fish.payara.samples.jaxws.security;
 
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
-import javax.net.ssl.*;
+import java.security.SecureRandom;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 
 public class InsecureSSLConfigurator {
 
@@ -13,12 +21,12 @@ public class InsecureSSLConfigurator {
         trustAllCertificates();
         allowAllHosts();
     }
-    
+
     public void revertSSLConfiguration() {
         switchBackToPreviousSSLFactory();
         switchBackToPreviousHostsVerifier();
     }
-    
+
     private void trustAllCertificates() throws KeyManagementException, NoSuchAlgorithmException {
         SSLSocketFactory trustingFactory = this.createTrustingSocketFactory();
         previousSSLFactory = HttpsURLConnection.getDefaultSSLSocketFactory();
@@ -43,8 +51,8 @@ public class InsecureSSLConfigurator {
         TrustManager[] trustAllCerts = new TrustManager[]{
             new TrustingX509TrustManager()
         };
-        SSLContext sc = SSLContext.getInstance("SSL");
-        sc.init(null, trustAllCerts, new java.security.SecureRandom());
+        SSLContext sc = SSLContext.getInstance("TLSv1.2");
+        sc.init(null, trustAllCerts, new SecureRandom());
         return sc.getSocketFactory();
     }
 
@@ -54,16 +62,20 @@ public class InsecureSSLConfigurator {
         public TrustingX509TrustManager() {
         }
 
+
+        @Override
         public java.security.cert.X509Certificate[] getAcceptedIssuers() {
             return null;
         }
 
-        public void checkClientTrusted(
-                java.security.cert.X509Certificate[] certs, String authType) {
+
+        @Override
+        public void checkClientTrusted(java.security.cert.X509Certificate[] certs, String authType) {
         }
 
-        public void checkServerTrusted(
-                java.security.cert.X509Certificate[] certs, String authType) {
+
+        @Override
+        public void checkServerTrusted(java.security.cert.X509Certificate[] certs, String authType) {
         }
     }
 

--- a/appserver/tests/payara-samples/samples/jaxws-security/src/test/java/fish/payara/samples/jaxws/security/ejb/EJBEndpointTest.java
+++ b/appserver/tests/payara-samples/samples/jaxws-security/src/test/java/fish/payara/samples/jaxws/security/ejb/EJBEndpointTest.java
@@ -39,33 +39,39 @@
  */
 package fish.payara.samples.jaxws.security.ejb;
 
-import fish.payara.samples.*;
+import fish.payara.samples.NotMicroCompatible;
+import fish.payara.samples.PayaraArquillianTestRunner;
+import fish.payara.samples.ServerOperations;
+import fish.payara.samples.SincePayara;
+import fish.payara.samples.Unstable;
+import fish.payara.samples.jaxws.security.JAXWSEndpointTest;
 
+import java.io.File;
+import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 
+import javax.net.ssl.HttpsURLConnection;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import fish.payara.samples.jaxws.security.JAXWSEndpointTest;
-import java.io.File;
-import java.io.IOException;
-import java.net.*;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import javax.net.ssl.HttpsURLConnection;
-import org.junit.*;
-import org.junit.experimental.categories.Category;
-
 @RunWith(PayaraArquillianTestRunner.class)
+@NotMicroCompatible
 @SincePayara("5.202")
 @Category(Unstable.class)
 public class EJBEndpointTest extends JAXWSEndpointTest {
+
+    private HttpsURLConnection serviceConnection;
 
     @Deployment
     public static WebArchive createDeployment() {
@@ -85,27 +91,31 @@ public class EJBEndpointTest extends JAXWSEndpointTest {
 
     @After
     public void cleanUp() {
+        if (serviceConnection != null) {
+            serviceConnection.disconnect();
+            serviceConnection = null;
+        }
         insecureSSLConfigurator.revertSSLConfiguration();
     }
 
     @Test
     @RunAsClient
     public void testUnrestrictedSoapRequest() throws IOException, URISyntaxException {
-        HttpsURLConnection serviceConnection = sendSoapHttpRequest("request.xml");
+        serviceConnection = sendSoapHttpRequest("request.xml");
         assertResponseOK(serviceConnection);
     }
 
     @Test
     @RunAsClient
     public void testPermittedSoapRequest() throws IOException, URISyntaxException {
-        HttpsURLConnection serviceConnection = sendSoapHttpRequest("request-restricted.xml");
+        serviceConnection = sendSoapHttpRequest("request-restricted.xml");
         assertResponseOK(serviceConnection);
     }
 
     @Test
     @RunAsClient
     public void testSoapRequestWithIncorrectCredentials() throws IOException, URISyntaxException {
-        HttpsURLConnection serviceConnection = sendSoapHttpRequest("request-with-bad-password.xml");
+        serviceConnection = sendSoapHttpRequest("request-with-bad-password.xml");
         assertResponseFailedWithMessage(serviceConnection, "Client not authorized");
 
     }
@@ -113,7 +123,7 @@ public class EJBEndpointTest extends JAXWSEndpointTest {
     @Test
     @RunAsClient
     public void testSoapRequestUserNotAllowedExecution() throws IOException, URISyntaxException {
-        HttpsURLConnection serviceConnection = sendSoapHttpRequest("request-not-allowed.xml");
+        serviceConnection = sendSoapHttpRequest("request-not-allowed.xml");
         assertResponseFailedWithMessage(serviceConnection, "Authentication of Username Password Token Failed");
     }
 

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -23,6 +23,7 @@
         <module>jacc-per-app</module>
         <module>jaxrs-rolesallowed</module>
         <module>jaxrs-rolesallowed-servlet</module>
+        <module>jaxws-security</module>
         <module>rest-management</module>
         <module>rolesPermitted</module>
         <module>oauth2</module>


### PR DESCRIPTION
- added jaxws-security to modules
- imports
- added NotMicroCompatible annotation (JAX-WS is not supported on micro)
- added disconnecting HttpsURLConnection after each test
- using TLS1.2 instead of SSL